### PR TITLE
Adding Documentation to Services and delimiter

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -2,13 +2,41 @@ import services.ConverterService;
 
 import java.io.IOException;
 
+/**
+ * Entry point of the application.
+ * <p>
+ * This class initializes the conversion process from a JSON file to a CSV file.
+ * It accepts input and output file paths (and an optional delimiter) as command-line arguments.
+ * If no arguments are provided, it falls back to default paths.
+ * </p>
+ *
+ * <h2>Usage</h2>
+ * <pre>
+ *     java -jar json2csv.jar input.json output.csv ";"
+ * </pre>
+ *
+ * <p>Arguments:</p>
+ * <ul>
+ *   <li><b>args[0]</b> - Path to the input JSON file (required)</li>
+ *   <li><b>args[1]</b> - Path to the output CSV file (required)</li>
+ *   <li><b>args[2]</b> - Delimiter to use in the CSV file (optional, default = ",")</li>
+ * </ul>
+ *
+ * @author Luis
+ * @version 0.1
+ */
 public class Main {
     public static void main(String[] args) throws IOException {
         String inputPath;
         String outputPath;
+        String delimiter;
+
+        System.out.println("Usage: java -jar json2csv.jar <input.json> <output.csv>");
+
         if (args.length < 2) {
             inputPath = "src/main/resources/cities.json";
-            outputPath = "src/main/resources/output2.csv";
+            outputPath = "src/main/resources/output3.csv";
+            delimiter = ",";
 
             System.out.println("⚠ No arguments provided, using default paths:");
             System.out.println("Input JSON: " + inputPath);
@@ -16,10 +44,11 @@ public class Main {
         } else {
             inputPath = args[0];
             outputPath = args[1];
+            delimiter = args[2];
         }
 
         ConverterService converter = new ConverterService();
-        converter.convert(inputPath, outputPath);
+        converter.convert(inputPath, outputPath,delimiter);
         System.out.println("Converted JSON: " + outputPath);
         System.out.println("Converted CSV: " + outputPath);
     }

--- a/src/main/java/models/CityRecord.java
+++ b/src/main/java/models/CityRecord.java
@@ -1,4 +1,21 @@
 package models;
 
+/**
+ * Represent a City record from the Json.
+ * <p>
+ *     Each record contains information about population, currency and flag.
+ * </p>
+ *
+ * @param name Name of the city.
+ * @param capital Capital of the city.
+ * @param population Population of the city.
+ * @param area Area of the city.
+ * @param currency Currency of the city.
+ * @param languages Languages of the city.
+ * @param region Region where is located.
+ * @param subregion Subregion where is located.
+ * @param flag Flag of the country.
+ */
+
 public record CityRecord(String name, String capital, int population, int area, String currency, String languages,
                          String region, String subregion, String flag) implements RecordType {}

--- a/src/main/java/services/ConverterService.java
+++ b/src/main/java/services/ConverterService.java
@@ -5,13 +5,33 @@ import models.CityRecord;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * Service class responsible for loading a JSON into a list of city records
+ * and sending the list to the {@link CsvWriterService} to writing into a CSV file.
+ * <p>
+ *     This class uses the services {@link JsonParserService} and {@link CsvWriterService}.
+ * </p>
+ *
+ * @author Luis
+ * @version 0.1
+ */
+
 public class ConverterService {
 
     private final JsonParserService jsonParserService = new JsonParserService();
     private final CsvWriterService csvWriterService = new CsvWriterService();
 
-    public void convert(String inputJson, String outputCsv) throws IOException {
+    /**
+     * Uses a {@link JsonParserService} to loads a JSON and use {@link CsvWriterService} to writing into a CSV.
+     *
+     * @param inputJson Path to the JSON file.
+     * @param outputCsv Path where the CSV file will be created.
+     * @param delimiter Delimiter to use in the CSV (e.g., "," or ";").
+     * @throws IOException if an error occurs while reading the JSON or writing the CSV.
+     */
+
+    public void convert(String inputJson, String outputCsv, String delimiter) throws IOException {
         List<CityRecord> cityRecords = jsonParserService.parseJson(inputJson);
-        csvWriterService.writerToCsv(cityRecords, outputCsv);
+        csvWriterService.writerToCsv(cityRecords, outputCsv, delimiter);
     }
 }

--- a/src/main/java/services/CsvWriterService.java
+++ b/src/main/java/services/CsvWriterService.java
@@ -6,30 +6,62 @@ import org.apache.commons.csv.CSVPrinter;
 
 import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Service class responsible for writing data into CSV file.
+ * <p>
+ *     This class uses apache commons CSV to generate CSV file
+ *     with dynamic headers obtained from the model.
+ * </p>
+ *
+ * @author Luis
+ * @version 0.1
+ */
+
 public class CsvWriterService {
-    private static final  String[] HEADERS = {
-            "name", "capital",  "population", "area", "currency", "languages", "region", "subregion", "flag"
-    };
 
-    public void writerToCsv(List<CityRecord> cityRecords, String outputFile) throws IOException {
+    /**
+     * Writes a list of {@link CityRecord} into a CSV file.
+     *
+     * @param cityRecords List of cities records to be written.
+     * @param outputFile Path where the CSV file will be created.
+     * @param delimiter To separate the columns of the record.
+     * @throws IOException If there is an error while writing the file.
+     * @throws IllegalArgumentException If the record list is empty.
+     */
+
+    public void writerToCsv(List<CityRecord> cityRecords, String outputFile, String delimiter) throws IOException {
+        if (cityRecords.isEmpty()) {
+            throw new IllegalArgumentException("City records cannot be empty");
+        }
+
+        RecordComponent[] components = CityRecord.class.getRecordComponents();
+        String[] recordHeaders = Arrays.stream(components)
+                .map(RecordComponent::getName)
+                .toArray(String[]::new);
+
+        System.out.println("Validating headers...");
+        System.out.println("Record headers: " + String.join(delimiter, recordHeaders));
+
         try (CSVPrinter printer = new CSVPrinter(new FileWriter(outputFile),
-                CSVFormat.DEFAULT.withHeader(HEADERS))) {
-
-            for (CityRecord cityRecord : cityRecords) {
-
-                printer.printRecord(
-                        cityRecord.name(),
-                        cityRecord.capital(),
-                        cityRecord.population(),
-                        cityRecord.area(),
-                        cityRecord.currency(),
-                        cityRecord.languages(),
-                        cityRecord.region(),
-                        cityRecord.subregion(),
-                        cityRecord.flag()
-                );
+                CSVFormat.Builder
+                        .create()
+                        .setHeader(recordHeaders)
+                        .setDelimiter(delimiter)
+                        .build())) {
+            for (CityRecord record : cityRecords) {
+                Object[] values = new Object[components.length];
+                for (int i = 0; i < components.length; i++) {
+                    try {
+                        values[i] = components[i].getAccessor().invoke(record);
+                    } catch (Exception e) {
+                        values[i] = "";
+                    }
+                }
+                printer.printRecord(values);
             }
         }
     }

--- a/src/main/java/services/JsonParserService.java
+++ b/src/main/java/services/JsonParserService.java
@@ -5,32 +5,67 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.lang.reflect.RecordComponent;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
+/**
+ * Service class responsible for load Json File.
+ * <p>
+ *     This class uses json.org to parse and manipulate Json.
+ * </p>
+ *
+ * @author Luis
+ * @version 0.1
+ */
 
 public class JsonParserService {
-    public List<CityRecord> parseJson(String filePath) throws IOException {
-        String content = Files.readString(Paths.get(filePath));
+    /**
+     * Loads a list of {@link CityRecord}.
+     *
+     * @param filePath Path to the JSON file.
+     * @throws IOException if an error occurs while loading the file.
+     * @return cityRecords list of records.
+     */
 
+    public List<CityRecord> parseJson(String filePath) throws IOException {
+
+        String content = Files.readString(Paths.get(filePath));
         JSONArray jsonArray = new JSONArray(content);
         List<CityRecord> cityRecords = new ArrayList<>();
+        RecordComponent[] components = CityRecord.class.getRecordComponents();
+        Set<String> recordNames = new HashSet<>();
+
+        for (RecordComponent recordComponent : components) {
+            recordNames.add(recordComponent.getName());
+        }
 
         for (int i = 0; i < jsonArray.length(); i++) {
+            JSONObject object = jsonArray.getJSONObject(i);
 
-            JSONObject jsonObject = jsonArray.getJSONObject(i);
+            Set<String> jsonKeys = object.keySet();
+            for (String name : recordNames) {
+                if (!jsonKeys.contains(name)) {
+                    throw new IllegalStateException(
+                            "Missing key in Json object at index: " + i + ":  " + name
+                    );
+                }
+            }
 
             CityRecord record = new CityRecord(
-                    jsonObject.optString("name"),
-                    jsonObject.optString("capital"),
-                    jsonObject.optInt("population"),
-                    jsonObject.optInt("area"),
-                    jsonObject.optString("currency"),
-                    jsonObject.optString("languages"),
-                    jsonObject.optString("region"),
-                    jsonObject.optString("subregion"),
-                    jsonObject.optString("flag")
+                    object.optString("name"),
+                    object.optString("capital"),
+                    object.optInt("population"),
+                    object.optInt("area"),
+                    object.optString("currency"),
+                    object.optString("languages"),
+                    object.optString("region"),
+                    object.optString("subregion"),
+                    object.optString("flag")
             );
             cityRecords.add(record);
         }

--- a/src/main/resources/cities.json
+++ b/src/main/resources/cities.json
@@ -42,5 +42,16 @@
     "region": "Europe",
     "subregion": "Western Europe",
     "flag": "https://upload.wikimedia.org/wikipedia/commons/6/65/Flag_of_Belgium.svg"
+  },
+  {
+    "name": "Mexico",
+    "capital": "Mexico",
+    "population": 11589623,
+    "area": 30528,
+    "currency": "Peso",
+    "languages": "Spanish",
+    "region": "Latam",
+    "subregion": "America Central",
+    "flag": "https://upload.wikimedia.org/wikipedia/commons/f/fc/Flag_of_Mexico.svg"
   }
 ]

--- a/src/main/resources/output3.csv
+++ b/src/main/resources/output3.csv
@@ -1,0 +1,6 @@
+name,capital,population,area,currency,languages,region,subregion,flag
+France,Paris,67364357,551695,Euro,French,Europe,Western Europe,https://upload.wikimedia.org/wikipedia/commons/c/c3/Flag_of_France.svg
+Germany,Berlin,83240525,357022,Euro,German,Europe,Western Europe,https://upload.wikimedia.org/wikipedia/commons/b/ba/Flag_of_Germany.svg
+United States,"Washington, D.C.",331893745,9833517,USD,English,Americas,Northern America,https://upload.wikimedia.org/wikipedia/commons/a/a4/Flag_of_the_United_States.svg
+Belgium,Brussels,11589623,30528,Euro,Flemish,Europe,Western Europe,https://upload.wikimedia.org/wikipedia/commons/6/65/Flag_of_Belgium.svg
+Mexico,Mexico,11589623,30528,Peso,Spanish,Latam,America Central,https://upload.wikimedia.org/wikipedia/commons/f/fc/Flag_of_Mexico.svg


### PR DESCRIPTION
### Summary
This PR improves ConverterService and CsvWriterService by:
- Adding Javadoc to classes and methods
- Validating CSV delimiter
- Handling empty JSON input
- Replacing deprecated CSVFormat.Builder.create() with CSVFormat.DEFAULT.builder()

### Why?
These changes improve code clarity, maintainability, and compatibility with the latest Apache Commons CSV.
